### PR TITLE
Install latest snapshot of terasoluna-gfw before running build. terasolunaorg/terasoluna-tourreservation#273

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,14 @@ cache:
   directories:
     - $HOME/.m2
 
-install: true
+install:
+  - pushd `pwd`
+  - cd $HOME/build
+  - if [[ -z $GFW_BRANCH ]]; then GFW_BRANCH=master; fi
+  - git clone --depth=1 --branch=$GFW_BRANCH https://github.com/terasolunaorg/terasoluna-gfw.git terasolunaorg/terasoluna-gfw
+  - cd terasolunaorg/terasoluna-gfw
+  - sh ./mvn-build-all.sh install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dsource.skip=true
+  - popd
 
 before_script:
   - psql -c 'create database tourreserve;' -U postgres


### PR DESCRIPTION
Please review terasolunaorg/terasoluna-tourreservation#273.

**Note:**

* For speedup, `git clone` for `terasoluna-gfw` perform with `--depth=1` option(latest history only). 
* For speedup, tests & generating javadoc jar & generating source jar for `terasoluna-gfw` skip on Travic-CI. 
* Default target branch of `terasoluna-gfw` is `master`. As option, target branch can override using `$GFW_BRANCH` (`$GFW_BRANCH` is adding by [settings page of Travis-CI](https://travis-ci.org/terasolunaorg/terasoluna-tourreservation/settings)).


