### PR TITLE
Remove failure-url JPA Test For Master #395

### DIFF
--- a/terasoluna-tourreservation-selenium/src/test/java/org/terasoluna/tourreservation/tourreserve/selenium/LogInLogOutTest.java
+++ b/terasoluna-tourreservation-selenium/src/test/java/org/terasoluna/tourreservation/tourreserve/selenium/LogInLogOutTest.java
@@ -18,7 +18,6 @@ package org.terasoluna.tourreservation.tourreserve.selenium;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.openqa.selenium.By.id;
 
 import org.junit.After;
 import org.junit.Before;

--- a/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/views/login/form.jsp
+++ b/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/views/login/form.jsp
@@ -6,6 +6,7 @@
         <legend>
           <spring:message code="label.tr.login.loginFormMessage" />
         </legend>
+        
         <c:if test="${param.containsKey('error')}">
 	        <span id="loginError"> 
 	          <t:messagesPanel messagesAttributeName="SPRING_SECURITY_LAST_EXCEPTION"/>


### PR DESCRIPTION
Please review #395 .
The import org.openqa.selenium.By.id is never used.
delete