### PR TITLE
[5.1.x] add firefox version at .travis.yml #496

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
   - oraclejdk8
 addons:
   postgresql: "9.4"
+  firefox: "38.8.0esr"
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
(cherry picked from commit 0d66d22327242bfe2b28584e74d8f775bfa132aa)

Please review #496 .
This PR is backport for 5.1.x .
