### PR TITLE
[1.0.x] Apply multiple module project to 5.0.x #494

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ before_script:
 
 script:
   - mvn -U sql:execute -f terasoluna-tourreservation-initdb/pom.xml -Ddb.password=
-  - mvn -U install -f terasoluna-tourreservation-parent/pom.xml
-  - mvn -U install -f terasoluna-tourreservation-env/pom.xml
-  - mvn -U install -f terasoluna-tourreservation-domain/pom.xml -Ddatabase.password=
-  - mvn -U install cargo:daemon-start -f terasoluna-tourreservation-web/pom.xml
+  - mvn -U install
+  - mvn -U cargo:daemon-start -f terasoluna-tourreservation-web/pom.xml
   - mvn -U test -f terasoluna-tourreservation-selenium/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ before_script:
   - psql -c 'create database tourreserve;' -U postgres
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - export MAVEN_DEPENDENCY_PLUGIN_VERSION=2.8
   - export CARGO_DAEMON_WEBAPP_VERSION=1.4.17
-  - mvn dependency:copy -Dartifact=org.codehaus.cargo:cargo-daemon-webapp:${CARGO_DAEMON_WEBAPP_VERSION}:war -DoutputDirectory=./target/.
+  - mvn org.apache.maven.plugins:maven-dependency-plugin:${MAVEN_DEPENDENCY_PLUGIN_VERSION}:copy -Dartifact=org.codehaus.cargo:cargo-daemon-webapp:${CARGO_DAEMON_WEBAPP_VERSION}:war -DoutputDirectory=./target/.
   - java -jar ./target/cargo-daemon-webapp-${CARGO_DAEMON_WEBAPP_VERSION}.war &
 
 script:

--- a/pom.xml
+++ b/pom.xml
@@ -2,18 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.terasoluna.app</groupId>
-    <artifactId>terasoluna-tourreservation-parent</artifactId>
-    <packaging>pom</packaging>
-    <parent>
-        <groupId>org.terasoluna.gfw</groupId>
-        <artifactId>terasoluna-gfw-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
-        <relativePath />
-    </parent>
 
-    <name>TERASOLUNA Global Framework - Tour Reservation Application - Parent</name>
+    <groupId>org.terasoluna.app</groupId>
+    <artifactId>terasoluna-tourreservation</artifactId>
     <version>1.0.7-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>TERASOLUNA Global Framework - Tour Reservation Application - Parent</name>
     <description>Parent POM of Tour Reservation Application using TERASOLUNA Global Framework</description>
     <url>http://terasoluna.org</url>
     <inceptionYear>2013</inceptionYear>
@@ -28,6 +22,14 @@
         <name>TERASOLUNA Framework</name>
         <url>http://terasoluna.org</url>
     </organization>
+
+    <parent>
+        <groupId>org.terasoluna.gfw</groupId>
+        <artifactId>terasoluna-gfw-parent</artifactId>
+        <version>1.0.7-SNAPSHOT</version>
+        <relativePath />
+    </parent>
+
     <build>
         <extensions>
             <extension>
@@ -282,7 +284,21 @@
     </reporting>
     <dependencyManagement>
         <dependencies>
-
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>terasoluna-tourreservation-domain</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>terasoluna-tourreservation-web</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>terasoluna-tourreservation-env</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- == Begin JasperReports == -->
             <dependency>
                 <groupId>jasperreports</groupId>
@@ -426,4 +442,9 @@
         <tiles.version>2.2.2</tiles.version>
         <tomcat.api.version>7.0.40</tomcat.api.version>
     </properties>
+    <modules>
+        <module>terasoluna-tourreservation-env</module>
+        <module>terasoluna-tourreservation-domain</module>
+        <module>terasoluna-tourreservation-web</module>
+    </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${org.apache.maven.plugins.maven-dependency-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>install</id>
@@ -423,7 +424,7 @@
         <org.apache.maven.archetype.version>2.2</org.apache.maven.archetype.version>
         <org.apache.maven.plugins.maven-checkstyle-plugin.version>2.9.1</org.apache.maven.plugins.maven-checkstyle-plugin.version>
         <org.apache.maven.plugins.maven-compiler-plugin.version>2.5.1</org.apache.maven.plugins.maven-compiler-plugin.version>
-        <org.apache.maven.plugins.maven-dependency-plugin.version>2.5</org.apache.maven.plugins.maven-dependency-plugin.version>
+        <org.apache.maven.plugins.maven-dependency-plugin.version>2.9</org.apache.maven.plugins.maven-dependency-plugin.version>
         <org.apache.maven.plugins.maven-javadoc-plugin.version>2.8.1</org.apache.maven.plugins.maven-javadoc-plugin.version>
         <org.apache.maven.plugins.maven-project-info-reports-plugin.version>2.5.1</org.apache.maven.plugins.maven-project-info-reports-plugin.version>
         <org.apache.maven.plugins.maven-resources-plugin.version>2.6</org.apache.maven.plugins.maven-resources-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>${org.apache.maven.plugins.maven-dependency-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>install</id>
@@ -424,7 +423,7 @@
         <org.apache.maven.archetype.version>2.2</org.apache.maven.archetype.version>
         <org.apache.maven.plugins.maven-checkstyle-plugin.version>2.9.1</org.apache.maven.plugins.maven-checkstyle-plugin.version>
         <org.apache.maven.plugins.maven-compiler-plugin.version>2.5.1</org.apache.maven.plugins.maven-compiler-plugin.version>
-        <org.apache.maven.plugins.maven-dependency-plugin.version>2.9</org.apache.maven.plugins.maven-dependency-plugin.version>
+        <org.apache.maven.plugins.maven-dependency-plugin.version>2.5</org.apache.maven.plugins.maven-dependency-plugin.version>
         <org.apache.maven.plugins.maven-javadoc-plugin.version>2.8.1</org.apache.maven.plugins.maven-javadoc-plugin.version>
         <org.apache.maven.plugins.maven-project-info-reports-plugin.version>2.5.1</org.apache.maven.plugins.maven-project-info-reports-plugin.version>
         <org.apache.maven.plugins.maven-resources-plugin.version>2.6</org.apache.maven.plugins.maven-resources-plugin.version>

--- a/terasoluna-tourreservation-domain/pom.xml
+++ b/terasoluna-tourreservation-domain/pom.xml
@@ -2,16 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.terasoluna.app</groupId>
-        <artifactId>terasoluna-tourreservation-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
-        <relativePath>../terasoluna-tourreservation-parent/pom.xml</relativePath>
-    </parent>
+
     <artifactId>terasoluna-tourreservation-domain</artifactId>
+    <packaging>jar</packaging>
     <name>TERASOLUNA Global Framework - Tour Reservation Application - Domain Layer</name>
     <description>Domain layer of Tour Reservation Application using TERASOLUNA Global Framework</description>
-    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.terasoluna.app</groupId>
+        <artifactId>terasoluna-tourreservation</artifactId>
+        <version>1.0.7-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <build>
         <plugins>
@@ -50,7 +52,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>terasoluna-tourreservation-env</artifactId>
-            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <!-- == End TourReservation == -->
 

--- a/terasoluna-tourreservation-env/pom.xml
+++ b/terasoluna-tourreservation-env/pom.xml
@@ -1,16 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.terasoluna.app</groupId>
-        <artifactId>terasoluna-tourreservation-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
-        <relativePath>../terasoluna-tourreservation-parent/pom.xml</relativePath>
-    </parent>
+
     <artifactId>terasoluna-tourreservation-env</artifactId>
+    <packaging>jar</packaging>
     <name>TERASOLUNA Global Framework - Tour Reservation Application - Environment Layer</name>
     <description>Environment dependent settings of Tour Reservation Application using TERASOLUNA Global Framework</description>
-    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.terasoluna.app</groupId>
+        <artifactId>terasoluna-tourreservation</artifactId>
+        <version>1.0.7-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <build>
         <finalName>${buildFinalName}</finalName>

--- a/terasoluna-tourreservation-initdb/pom.xml
+++ b/terasoluna-tourreservation-initdb/pom.xml
@@ -2,16 +2,16 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.terasoluna.app</groupId>
-        <artifactId>terasoluna-tourreservation-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
-        <relativePath>../terasoluna-tourreservation-parent/pom.xml</relativePath>
-    </parent>
-
     <artifactId>terasoluna-tourreservation-initdb</artifactId>
     <name>TERASOLUNA Global Framework - Tour Reservation Application - DB Init</name>
     <description>Db initialization scripts for Tour Reservation Application using TERASOLUNA Global Framework</description>
+
+    <parent>
+        <groupId>org.terasoluna.app</groupId>
+        <artifactId>terasoluna-tourreservation</artifactId>
+        <version>1.0.7-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <profiles>
         <profile>

--- a/terasoluna-tourreservation-selenium/pom.xml
+++ b/terasoluna-tourreservation-selenium/pom.xml
@@ -2,16 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>terasoluna-tourreservation-parent</artifactId>
-        <groupId>org.terasoluna.app</groupId>
-        <version>1.0.7-SNAPSHOT</version>
-        <relativePath>../terasoluna-tourreservation-parent/pom.xml</relativePath>
-    </parent>
+
     <artifactId>terasoluna-tourreservation-selenium</artifactId>
+    <packaging>jar</packaging>
     <name>TERASOLUNA Global Framework - Tour Reservation Application - Selenium</name>
     <description>Selenium tests for Tour Reservation Application using TERASOLUNA Global Framework</description>
-    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.terasoluna.app</groupId>
+        <artifactId>terasoluna-tourreservation</artifactId>
+        <version>1.0.7-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <build>
         <plugins>
@@ -50,7 +52,11 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>terasoluna-tourreservation-domain</artifactId>
-            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>terasoluna-tourreservation-env</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/terasoluna-tourreservation-web/pom.xml
+++ b/terasoluna-tourreservation-web/pom.xml
@@ -2,16 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.terasoluna.app</groupId>
-        <artifactId>terasoluna-tourreservation-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
-        <relativePath>../terasoluna-tourreservation-parent/pom.xml</relativePath>
-    </parent>
     <artifactId>terasoluna-tourreservation-web</artifactId>
+    <packaging>war</packaging>
     <name>TERASOLUNA Global Framework - Tour Reservation Application - Web Layer</name>
     <description>Web layer of Tour Reservation Application using TERASOLUNA Global Framework</description>
-    <packaging>war</packaging>
+
+    <parent>
+        <groupId>org.terasoluna.app</groupId>
+        <artifactId>terasoluna-tourreservation</artifactId>
+        <version>1.0.7-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <build>
         <plugins>
@@ -54,7 +55,6 @@
                 <dependency>
                     <groupId>${project.groupId}</groupId>
                     <artifactId>terasoluna-tourreservation-env</artifactId>
-                    <version>${project.version}</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -70,13 +70,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>terasoluna-tourreservation-domain</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>terasoluna-tourreservation-env</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- == End TourReservation == -->
 


### PR DESCRIPTION
Please review #494 .

This PR is backport for 1.0.x .

When version of maven-dependency-plugin is 2.5, `dependency:copy` goal fails, so it was raised to 2.9 at fbb0e124336a668ee59fd7172933bfb7653665f3 commit .