### PR TITLE
update to 5.5.0.RC2-SNAPSHOT #567

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 install:
   - pushd `pwd`
   - cd $HOME/build
-  - if [[ -z $GFW_BRANCH ]]; then GFW_BRANCH=master; fi
+  - if [[ -z $GFW_BRANCH ]]; then GFW_BRANCH=5.5.0.RC2-development; fi
   - git clone --depth=1 --branch=$GFW_BRANCH https://github.com/terasolunaorg/terasoluna-gfw.git terasolunaorg/terasoluna-gfw
   - cd terasolunaorg/terasoluna-gfw
   - sh ./mvn-build-all.sh install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dsource.skip=true
@@ -22,7 +22,7 @@ before_script:
   - psql -c 'create database tourreserve;' -U postgres
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - export CARGO_DAEMON_WEBAPP_VERSION=1.4.17
+  - export CARGO_DAEMON_WEBAPP_VERSION=1.6.2
   - mvn dependency:copy -Dartifact=org.codehaus.cargo:cargo-daemon-webapp:${CARGO_DAEMON_WEBAPP_VERSION}:war -DoutputDirectory=./target/.
   - java -jar ./target/cargo-daemon-webapp-${CARGO_DAEMON_WEBAPP_VERSION}.war &
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.terasoluna.app</groupId>
   <artifactId>terasoluna-tourreservation</artifactId>
-  <version>5.5.0-SNAPSHOT</version>
+  <version>5.5.0.RC2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>TERASOLUNA Server Framework for Java (5.x) - Tour Reservation Application - Parent</name>
   <description>Parent POM of Tour Reservation Application using TERASOLUNA Server Framework for Java (5.x)</description>
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.terasoluna.gfw</groupId>
     <artifactId>terasoluna-gfw-parent</artifactId>
-    <version>5.5.0-SNAPSHOT</version>
+    <version>5.5.0.RC2-SNAPSHOT</version>
     <relativePath />
   </parent>
 

--- a/terasoluna-tourreservation-domain/pom.xml
+++ b/terasoluna-tourreservation-domain/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.terasoluna.app</groupId>
     <artifactId>terasoluna-tourreservation</artifactId>
-    <version>5.5.0-SNAPSHOT</version>
+    <version>5.5.0.RC2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/model/Accommodation.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/model/Accommodation.java
@@ -32,11 +32,14 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.hibernate.annotations.Proxy;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @Data
+@Proxy(lazy = false)
 @ToString(exclude = "tourinfoList")
 @EqualsAndHashCode(exclude = "tourinfoList")
 @Entity

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/model/Arrival.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/model/Arrival.java
@@ -32,11 +32,14 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.hibernate.annotations.Proxy;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @Data
+@Proxy(lazy = false)
 @ToString(exclude = "tourinfoList")
 @EqualsAndHashCode(exclude = "tourinfoList")
 @Entity

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/model/Departure.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/model/Departure.java
@@ -32,11 +32,14 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.hibernate.annotations.Proxy;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @Data
+@Proxy(lazy = false)
 @ToString(exclude = "tourinfoList")
 @EqualsAndHashCode(exclude = "tourinfoList")
 @Entity

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/repository/tourinfo/TourInfoRepositoryImpl.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/repository/tourinfo/TourInfoRepositoryImpl.java
@@ -62,7 +62,7 @@ public class TourInfoRepositoryImpl implements TourInfoRepositoryCustom {
             query.setParameter("basePrice", criteria.getBasePrice());
         }
 
-        query.setFirstResult(pageable.getOffset());
+        query.setFirstResult((int) pageable.getOffset());
         query.setMaxResults(pageable.getPageSize());
 
         List<TourInfo> tourInfoList = query.getResultList();

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/customer/CustomerServiceImpl.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/customer/CustomerServiceImpl.java
@@ -40,7 +40,7 @@ public class CustomerServiceImpl implements CustomerService {
 
     @Override
     public Customer findOne(String customerCode) {
-        return customerRepository.findOne(customerCode);
+        return customerRepository.findById(customerCode).orElse(null);
     }
 
     @Override

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/reserve/AuthorizedReserveSharedServiceImpl.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/reserve/AuthorizedReserveSharedServiceImpl.java
@@ -34,7 +34,7 @@ public class AuthorizedReserveSharedServiceImpl implements
     @PostAuthorize("returnObject == null or returnObject.customer.customerCode == principal.customer.customerCode")
     @Override
     public Reserve findOne(String reserveNo) {
-        return reserveRepository.findOne(reserveNo);
+        return reserveRepository.findById(reserveNo).orElse(null);
     }
 
 }

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImpl.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImpl.java
@@ -173,7 +173,7 @@ public class ReserveServiceImpl implements ReserveService {
         // reserve = reserveRepository.findForUpdate(reserveNo); TODO
         reserve = reserveRepository.findOneForUpdate(reserveNo);
         if (reserve != null) {
-            reserveRepository.delete(reserveNo);
+            reserveRepository.deleteById(reserveNo);
         } else {
             ResultMessages message = ResultMessages.error().add(
                     MessageId.E_TR_0003);

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/tourinfo/PriceCalculateSharedServiceImpl.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/tourinfo/PriceCalculateSharedServiceImpl.java
@@ -73,8 +73,8 @@ public class PriceCalculateSharedServiceImpl implements
             @Override
             protected void doInTransactionWithoutResult(
                     TransactionStatus status) {
-                childAge = ageRepository.findOne("1");
-                adultAge = ageRepository.findOne("0");
+                childAge = ageRepository.findById("1").orElse(null);
+                adultAge = ageRepository.findById("0").orElse(null);
             }
         });
     }

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoSharedServiceImpl.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoSharedServiceImpl.java
@@ -40,7 +40,7 @@ public class TourInfoSharedServiceImpl implements TourInfoSharedService {
 
     @Override
     public TourInfo findOne(String tourCode) {
-        return tourInfoRepository.findOne(tourCode);
+        return tourInfoRepository.findById(tourCode).orElse(null);
     }
 
     @Override

--- a/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/userdetails/ReservationUserDetailsService.java
+++ b/terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/userdetails/ReservationUserDetailsService.java
@@ -30,7 +30,7 @@ public class ReservationUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(
             String username) throws UsernameNotFoundException {
-        Customer customer = customerRepository.findOne(username);
+        Customer customer = customerRepository.findById(username).orElse(null);
         if (customer == null) {
             throw new UsernameNotFoundException(username + " is not found.");
         }

--- a/terasoluna-tourreservation-domain/src/main/resources/META-INF/dozer/domain-mapping.xml
+++ b/terasoluna-tourreservation-domain/src/main/resources/META-INF/dozer/domain-mapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mappings xmlns="http://dozer.sourceforge.net" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://dozer.sourceforge.net
-          http://dozer.sourceforge.net/schema/beanmapping.xsd">
+<mappings xmlns="http://dozermapper.github.io/schema/bean-mapping"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://dozermapper.github.io/schema/bean-mapping https://dozermapper.github.io/schema/bean-mapping.xsd">
 
   <configuration>
     <copy-by-references>

--- a/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/repository/tourinfo/TourInfoRepositoryImplTest.java
+++ b/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/repository/tourinfo/TourInfoRepositoryImplTest.java
@@ -110,7 +110,7 @@ public class TourInfoRepositoryImplTest {
         criteria.setDepCode("01");
         criteria.setTourDays(0);
 
-        Pageable pageable = new PageRequest(0, 10);
+        Pageable pageable = PageRequest.of(0, 10);
 
         // run
         Page<TourInfo> page = tourInfoRepository.findPageBySearchCriteria(
@@ -156,7 +156,7 @@ public class TourInfoRepositoryImplTest {
         criteria.setDepCode("01");
         criteria.setTourDays(2);
 
-        Pageable pageable = new PageRequest(0, 10);
+        Pageable pageable = PageRequest.of(0, 10);
         // run
         Page<TourInfo> page = tourInfoRepository.findPageBySearchCriteria(
                 criteria, pageable);

--- a/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/customer/CustomerServiceImplTest.java
+++ b/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/customer/CustomerServiceImplTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +59,7 @@ public class CustomerServiceImplTest {
     @Test
     public void testFindOne01() {
         Customer c = new Customer();
-        when(customerRepository.findOne("xxx")).thenReturn(c);
+        when(customerRepository.findById("xxx")).thenReturn(Optional.of(c));
 
         Customer result = customerService.findOne("xxx");
         assertThat(result, is(c));
@@ -65,7 +67,7 @@ public class CustomerServiceImplTest {
 
     @Test
     public void testFindOne02() {
-        when(customerRepository.findOne("xxx")).thenReturn(null);
+        when(customerRepository.findById("xxx")).thenReturn(Optional.empty());
 
         Customer result = customerService.findOne("xxx");
         assertThat(result, is(nullValue()));

--- a/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplSecurityTest.java
+++ b/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplSecurityTest.java
@@ -15,7 +15,25 @@
  */
 package org.terasoluna.tourreservation.domain.service.reserve;
 
-import org.junit.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -27,20 +45,13 @@ import org.springframework.security.test.context.support.WithSecurityContextFact
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.terasoluna.gfw.common.date.jodatime.JodaTimeDateFactory;
-import org.terasoluna.tourreservation.domain.model.*;
+import org.terasoluna.tourreservation.domain.model.Arrival;
+import org.terasoluna.tourreservation.domain.model.Customer;
+import org.terasoluna.tourreservation.domain.model.Departure;
+import org.terasoluna.tourreservation.domain.model.Reserve;
+import org.terasoluna.tourreservation.domain.model.TourInfo;
 import org.terasoluna.tourreservation.domain.repository.reserve.ReserveRepository;
 import org.terasoluna.tourreservation.domain.service.userdetails.ReservationUserDetails;
-
-import javax.inject.Inject;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -148,7 +159,7 @@ public class ReserveServiceImplSecurityTest {
 
         // assert
         {
-            verify(mockReserveRepository, times(1)).save((Reserve) anyObject());
+            verify(mockReserveRepository, times(1)).save(any(Reserve.class));
             assertThat(output.getReserve().getReserveNo(), is("R000000001"));
             assertThat(output.getReserve().getCustomer().getCustomerCode(), is(
                     CUSTOMER_A));
@@ -179,7 +190,7 @@ public class ReserveServiceImplSecurityTest {
 
         // assert
         {
-            verify(mockReserveRepository, never()).save((Reserve) anyObject());
+            verify(mockReserveRepository, never()).save(any(Reserve.class));
         }
     }
 
@@ -199,7 +210,7 @@ public class ReserveServiceImplSecurityTest {
 
         // assert
         {
-            verify(mockReserveRepository, times(1)).delete("R000000001");
+            verify(mockReserveRepository, times(1)).deleteById("R000000001");
         }
 
     }
@@ -225,7 +236,7 @@ public class ReserveServiceImplSecurityTest {
 
         // assert
         {
-            verify(mockReserveRepository, never()).delete("R000000001");
+            verify(mockReserveRepository, never()).deleteById("R000000001");
         }
 
     }
@@ -251,7 +262,8 @@ public class ReserveServiceImplSecurityTest {
         tourInfo.setArrival(new Arrival());
         reserve.setTourInfo(tourInfo);
 
-        when(mockReserveRepository.findOne(reserveNo)).thenReturn(reserve);
+        when(mockReserveRepository.findById(reserveNo)).thenReturn(Optional.of(
+                reserve));
         when(mockReserveRepository.findOneForUpdate(reserveNo)).thenReturn(
                 reserve);
     }

--- a/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplTest.java
+++ b/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplTest.java
@@ -25,12 +25,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.terasoluna.gfw.common.message.StandardResultMessageType.ERROR;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
-import org.dozer.DozerBeanMapper;
+import org.dozer.DozerBeanMapperBuilder;
+import org.dozer.Mapper;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -40,7 +43,6 @@ import org.terasoluna.gfw.common.date.jodatime.JodaTimeDateFactory;
 import org.terasoluna.gfw.common.exception.BusinessException;
 import org.terasoluna.gfw.common.message.ResultMessageType;
 import org.terasoluna.gfw.common.message.ResultMessages;
-import static org.terasoluna.gfw.common.message.StandardResultMessageType.*;
 import org.terasoluna.gfw.common.sequencer.Sequencer;
 import org.terasoluna.tourreservation.domain.common.constants.MessageId;
 import org.terasoluna.tourreservation.domain.model.Accommodation;
@@ -68,7 +70,7 @@ public class ReserveServiceImplTest {
 
     Sequencer<String> sequencer;
 
-    DozerBeanMapper beanMapper;
+    Mapper beanMapper;
 
     DateTime now = new DateTime();
 
@@ -84,10 +86,10 @@ public class ReserveServiceImplTest {
         AuthorizedReserveSharedServiceImpl authorizedReserveSharedService = new AuthorizedReserveSharedServiceImpl();
         authorizedReserveSharedService.reserveRepository = reserveRepository;
 
-        beanMapper = new DozerBeanMapper();
         List<String> mappingFiles = new ArrayList<String>();
         mappingFiles.add("META-INF/dozer/domain-mapping.xml");
-        beanMapper.setMappingFiles(mappingFiles);
+        beanMapper = DozerBeanMapperBuilder.create().withMappingFiles(
+                mappingFiles).build();
 
         reserveService.reserveRepository = reserveRepository;
         reserveService.tourInfoSharedService = tourInfoSharedService;
@@ -107,7 +109,8 @@ public class ReserveServiceImplTest {
     @Test
     public void testFindOne01() {
         Reserve reserve = new Reserve();
-        when(reserveRepository.findOne("foo")).thenReturn(reserve);
+        when(reserveRepository.findById("foo")).thenReturn(Optional.of(
+                reserve));
 
         Reserve result = reserveService.findOne("foo");
         assertThat(result, is(reserve));
@@ -115,7 +118,7 @@ public class ReserveServiceImplTest {
 
     @Test
     public void testFindOne02() {
-        when(reserveRepository.findOne("foo")).thenReturn(null);
+        when(reserveRepository.findById("foo")).thenReturn(Optional.empty());
 
         Reserve result = reserveService.findOne("foo");
         assertThat(result, is(nullValue()));
@@ -307,7 +310,8 @@ public class ReserveServiceImplTest {
         reserve.setTourInfo(tour);
         reserve.setTransfer(Reserve.NOT_TRANSFERED);
 
-        when(reserveRepository.findOne("001")).thenReturn(reserve);
+        when(reserveRepository.findById("001")).thenReturn(Optional.of(
+                reserve));
         when(reserveRepository.findOneForUpdate("001")).thenReturn(reserve);
         when(tourInfoSharedService.isOverPaymentLimit(tour)).thenReturn(false); // within limit
 
@@ -315,7 +319,7 @@ public class ReserveServiceImplTest {
 
         ArgumentCaptor<String> argOfDelete = ArgumentCaptor.forClass(
                 String.class);
-        verify(reserveRepository, times(1)).delete(argOfDelete.capture());
+        verify(reserveRepository, times(1)).deleteById(argOfDelete.capture());
 
         assertThat(argOfDelete.getValue(), is("001"));
     }
@@ -330,7 +334,8 @@ public class ReserveServiceImplTest {
         reserve.setTourInfo(tour);
         reserve.setTransfer(Reserve.TRANSFERED); // !!!TRANSFERED
 
-        when(reserveRepository.findOne("001")).thenReturn(reserve);
+        when(reserveRepository.findById("001")).thenReturn(Optional.of(
+                reserve));
         when(reserveRepository.findOneForUpdate("001")).thenReturn(reserve);
         when(tourInfoSharedService.isOverPaymentLimit(tour)).thenReturn(false); // within limit
 
@@ -358,7 +363,8 @@ public class ReserveServiceImplTest {
         reserve.setTourInfo(tour);
         reserve.setTransfer(Reserve.NOT_TRANSFERED);
 
-        when(reserveRepository.findOne("001")).thenReturn(reserve);
+        when(reserveRepository.findById("001")).thenReturn(Optional.of(
+                reserve));
         when(reserveRepository.findOneForUpdate("001")).thenReturn(reserve);
         when(tourInfoSharedService.isOverPaymentLimit(tour)).thenReturn(true); // !!!over limit
 
@@ -386,8 +392,8 @@ public class ReserveServiceImplTest {
         reserve.setTourInfo(tour);
         reserve.setTransfer(Reserve.NOT_TRANSFERED);
 
-        when(reserveRepository.findOne("001")).thenReturn(reserve,
-                (Reserve) null); // !!!return null for second time
+        when(reserveRepository.findById("001")).thenReturn(Optional.of(reserve))
+                .thenReturn(Optional.empty()); // !!!return null for second time
         when(reserveRepository.findOneForUpdate("001")).thenReturn(
                 (Reserve) null); // return null
         when(tourInfoSharedService.isOverPaymentLimit(tour)).thenReturn(false); // within limit
@@ -427,7 +433,8 @@ public class ReserveServiceImplTest {
         tour.setBasePrice(10000);
         reserve.setTourInfo(tour);
 
-        when(reserveRepository.findOne("foo")).thenReturn(reserve);
+        when(reserveRepository.findById("foo")).thenReturn(Optional.of(
+                reserve));
         when(reserveRepository.findOneForUpdate("foo")).thenReturn(reserve);
         when(reserveRepository.save(reserve)).thenReturn(reserve);
         // run

--- a/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoServiceImplTest.java
+++ b/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoServiceImplTest.java
@@ -64,7 +64,7 @@ public class TourInfoServiceImplTest {
     public void testSearchTourInfo01() {
 
         TourInfoSearchCriteria criteria = new TourInfoSearchCriteria();
-        Pageable pageable = new PageRequest(0, 10);
+        Pageable pageable = PageRequest.of(0, 10);
 
         List<TourInfo> mockedList = new ArrayList<TourInfo>();
 

--- a/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoSharedServiceImplTest.java
+++ b/terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoSharedServiceImplTest.java
@@ -16,9 +16,11 @@
 package org.terasoluna.tourreservation.domain.service.tourinfo;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -55,7 +57,7 @@ public class TourInfoSharedServiceImplTest {
     public void testFindOne01() {
         TourInfo info = new TourInfo();
 
-        when(tourInfoRepository.findOne("foo")).thenReturn(info);
+        when(tourInfoRepository.findById("foo")).thenReturn(Optional.of(info));
 
         // run
         TourInfo result = tourInfoSharedService.findOne("foo");

--- a/terasoluna-tourreservation-domain/src/test/resources/test-context.xml
+++ b/terasoluna-tourreservation-domain/src/test/resources/test-context.xml
@@ -24,7 +24,7 @@
 
   <bean id="exceptionLogger" class="org.terasoluna.gfw.common.exception.ExceptionLogger" />
 
-  <bean class="org.dozer.spring.DozerBeanMapperFactoryBean">
+  <bean class="com.github.dozermapper.spring.DozerBeanMapperFactoryBean">
     <property name="mappingFiles" value="classpath*:/META-INF/dozer/**/*-mapping.xml" />
   </bean>
 

--- a/terasoluna-tourreservation-env/pom.xml
+++ b/terasoluna-tourreservation-env/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.terasoluna.app</groupId>
     <artifactId>terasoluna-tourreservation</artifactId>
-    <version>5.5.0-SNAPSHOT</version>
+    <version>5.5.0.RC2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/terasoluna-tourreservation-initdb/pom.xml
+++ b/terasoluna-tourreservation-initdb/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.terasoluna.app</groupId>
     <artifactId>terasoluna-tourreservation</artifactId>
-    <version>5.5.0-SNAPSHOT</version>
+    <version>5.5.0.RC2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/terasoluna-tourreservation-selenium/pom.xml
+++ b/terasoluna-tourreservation-selenium/pom.xml
@@ -9,7 +9,7 @@
   <description>Selenium tests for Tour Reservation Application using TERASOLUNA Server Framework for Java (5.x)</description>
 
   <parent>
-    <version>5.5.0-SNAPSHOT</version>
+    <version>5.5.0.RC2-SNAPSHOT</version>
     <artifactId>terasoluna-tourreservation</artifactId>
     <groupId>org.terasoluna.app</groupId>
     <relativePath>../pom.xml</relativePath>

--- a/terasoluna-tourreservation-web/pom.xml
+++ b/terasoluna-tourreservation-web/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.terasoluna.app</groupId>
     <artifactId>terasoluna-tourreservation</artifactId>
-    <version>5.5.0-SNAPSHOT</version>
+    <version>5.5.0.RC2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/terasoluna-tourreservation-web/src/main/resources/META-INF/spring/applicationContext.xml
+++ b/terasoluna-tourreservation-web/src/main/resources/META-INF/spring/applicationContext.xml
@@ -12,7 +12,7 @@
 
   <context:property-placeholder location="classpath*:/META-INF/spring/*.properties" />
 
-  <bean class="org.dozer.spring.DozerBeanMapperFactoryBean">
+  <bean class="com.github.dozermapper.spring.DozerBeanMapperFactoryBean">
     <property name="mappingFiles" value="classpath*:/META-INF/dozer/**/*-mapping.xml" />
   </bean>
 

--- a/terasoluna-tourreservation-web/src/main/resources/META-INF/spring/spring-mvc.xml
+++ b/terasoluna-tourreservation-web/src/main/resources/META-INF/spring/spring-mvc.xml
@@ -77,9 +77,9 @@
   </mvc:tiles-configurer>
 
 
-  <bean id="managereservation/report" class="org.springframework.web.servlet.view.jasperreports.JasperReportsPdfView">
+  <!--<bean id="managereservation/report" class="org.springframework.web.servlet.view.jasperreports.JasperReportsPdfView">
     <property name="url" value="/WEB-INF/reports/reservationReportPdf.jrxml" />
-  </bean>
+  </bean>-->
 
   <bean id="requestDataValueProcessor" class="org.terasoluna.gfw.web.mvc.support.CompositeRequestDataValueProcessor">
     <constructor-arg>

--- a/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managecustomer/ManageCustomerControllerTest.java
+++ b/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managecustomer/ManageCustomerControllerTest.java
@@ -15,13 +15,13 @@
  */
 package org.terasoluna.tourreservation.app.managecustomer;
 
-import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
@@ -29,7 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import org.dozer.DozerBeanMapper;
+import org.dozer.DozerBeanMapperBuilder;
+import org.dozer.Mapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.web.servlet.MockMvc;
@@ -57,7 +58,7 @@ public class ManageCustomerControllerTest {
         CustomerPassEqualsValidator cpev = new CustomerPassEqualsValidator();
         CustomerBirthdayValidator cbv = new CustomerBirthdayValidator();
 
-        DozerBeanMapper beanMapper = new DozerBeanMapper();
+        Mapper beanMapper = DozerBeanMapperBuilder.buildDefault();
 
         // Whenever mapping files are required, can be set as shown below
 
@@ -233,7 +234,7 @@ public class ManageCustomerControllerTest {
         MockHttpServletRequestBuilder postRequest = MockMvcRequestBuilders.post(
                 "/customers/create");
 
-        when(customerService.register((Customer) anyObject(), eq("12345")))
+        when(customerService.register(any(Customer.class), eq("12345")))
                 .thenReturn(new Customer("12345678"));
 
         CustomerForm form = prepareNewForm();
@@ -264,7 +265,7 @@ public class ManageCustomerControllerTest {
         MockHttpServletRequestBuilder postRequest = MockMvcRequestBuilders.post(
                 "/customers/create");
 
-        when(customerService.register((Customer) anyObject(), eq("12345")))
+        when(customerService.register(any(Customer.class), eq("12345")))
                 .thenReturn(new Customer("12345678"));
 
         CustomerForm form = prepareNewForm();

--- a/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managereservation/ManageReservationControllerTest.java
+++ b/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managereservation/ManageReservationControllerTest.java
@@ -17,8 +17,8 @@ package org.terasoluna.tourreservation.app.managereservation;
 
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 
-import org.dozer.DozerBeanMapper;
+import org.dozer.DozerBeanMapperBuilder;
 import org.dozer.Mapper;
 import org.hamcrest.core.IsNull;
 import org.junit.Before;
@@ -73,7 +73,7 @@ public class ManageReservationControllerTest {
         // other members instantiation and assignment
         manageReservationHelper = mock(ManageReservationHelper.class);
         manageReservationHelper.existenceCodeList = mock(I18nCodeList.class);
-        beanMapper = new DozerBeanMapper();
+        beanMapper = DozerBeanMapperBuilder.buildDefault();
         reserveService = mock(ReserveService.class);
         userDetails = mock(ReservationUserDetails.class);
         manageReservationController.manageReservationHelper = manageReservationHelper;
@@ -192,8 +192,8 @@ public class ManageReservationControllerTest {
                 "/reservations/123/update").param("confirm", "");
 
         // Set mock behavior for helper method
-        when(manageReservationHelper.findDetail(eq("123"),
-                (ManageReservationForm) anyObject())).thenReturn(
+        when(manageReservationHelper.findDetail(eq("123"), any(
+                ManageReservationForm.class))).thenReturn(
                         new ReservationDetailOutput());
 
         // Set form data to pass @Validated check
@@ -253,7 +253,7 @@ public class ManageReservationControllerTest {
                 "/reservations/123/update");
 
         // Set mock behavior for helper method
-        when(reserveService.update((ReservationUpdateInput) anyObject()))
+        when(reserveService.update(any(ReservationUpdateInput.class)))
                 .thenReturn(new ReservationUpdateOutput());
 
         // Set form data to pass @Validated check

--- a/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourControllerTest.java
+++ b/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourControllerTest.java
@@ -17,8 +17,8 @@ package org.terasoluna.tourreservation.app.reservetour;
 
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
@@ -74,10 +74,8 @@ public class ReserveTourControllerTest {
                 "/tours/123/reserve").param("form", "");
 
         // Set mock behavior for helper method
-        when(reserveTourHelper.findTourDetail(
-                (ReservationUserDetails) anyObject(), eq("123"),
-                (ReserveTourForm) anyObject())).thenReturn(
-                        new TourDetailOutput());
+        when(reserveTourHelper.findTourDetail(any(), eq("123"), any()))
+                .thenReturn(new TourDetailOutput());
 
         try {
             ResultActions results = mockMvc.perform(getRequest);
@@ -102,10 +100,8 @@ public class ReserveTourControllerTest {
                 "/tours/123").param("form", "");
 
         // Set mock behavior for helper method
-        when(reserveTourHelper.findTourDetail(
-                (ReservationUserDetails) anyObject(), eq("123"),
-                (ReserveTourForm) anyObject())).thenReturn(
-                        new TourDetailOutput());
+        when(reserveTourHelper.findTourDetail(any(), eq("123"), any()))
+                .thenReturn(new TourDetailOutput());
 
         try {
             ResultActions results = mockMvc.perform(getRequest);
@@ -130,10 +126,8 @@ public class ReserveTourControllerTest {
                 "/tours/123/reserve").param("confirm", "");
 
         // Set mock behavior for helper method
-        when(reserveTourHelper.findTourDetail(
-                (ReservationUserDetails) anyObject(), eq("123"),
-                (ReserveTourForm) anyObject())).thenReturn(
-                        new TourDetailOutput());
+        when(reserveTourHelper.findTourDetail(any(), eq("123"), any()))
+                .thenReturn(new TourDetailOutput());
 
         // Set form data
         postRequest.param("adultCount", "2");
@@ -162,10 +156,8 @@ public class ReserveTourControllerTest {
                 "/tours/123/reserve").param("confirm", "");
 
         // Set mock behavior for helper method
-        when(reserveTourHelper.findTourDetail(
-                (ReservationUserDetails) anyObject(), eq("123"),
-                (ReserveTourForm) anyObject())).thenReturn(
-                        new TourDetailOutput());
+        when(reserveTourHelper.findTourDetail(any(), eq("123"), any()))
+                .thenReturn(new TourDetailOutput());
 
         // Do not Set any form data so that form validation will fail
         // Just perform the request
@@ -194,9 +186,8 @@ public class ReserveTourControllerTest {
                 "/tours/123/reserve");
 
         // Set mock behavior for helper method
-        when(reserveTourHelper.reserve((ReservationUserDetails) anyObject(), eq(
-                "123"), (ReserveTourForm) anyObject())).thenReturn(
-                        new ReserveTourOutput());
+        when(reserveTourHelper.reserve(any(), eq("123"), any())).thenReturn(
+                new ReserveTourOutput());
 
         postRequest.param("adultCount", "2");
         postRequest.param("childCount", "2");
@@ -224,13 +215,10 @@ public class ReserveTourControllerTest {
                 "/tours/123/reserve");
 
         // Set mock behavior for helper method
-        when(reserveTourHelper.reserve((ReservationUserDetails) anyObject(), eq(
-                "123"), (ReserveTourForm) anyObject())).thenThrow(
-                        new BusinessException(""));
-        when(reserveTourHelper.findTourDetail(
-                (ReservationUserDetails) anyObject(), eq("123"),
-                (ReserveTourForm) anyObject())).thenReturn(
-                        new TourDetailOutput());
+        when(reserveTourHelper.reserve(any(), eq("123"), any())).thenThrow(
+                new BusinessException(""));
+        when(reserveTourHelper.findTourDetail(any(), eq("123"), any()))
+                .thenReturn(new TourDetailOutput());
 
         // Set form data
         postRequest.param("adultCount", "2");

--- a/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourHelperTest.java
+++ b/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourHelperTest.java
@@ -18,18 +18,16 @@ package org.terasoluna.tourreservation.app.reservetour;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.dozer.DozerBeanMapper;
+import org.dozer.DozerBeanMapperBuilder;
 import org.dozer.Mapper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.terasoluna.tourreservation.domain.model.Accommodation;
 import org.terasoluna.tourreservation.domain.model.Arrival;
 import org.terasoluna.tourreservation.domain.model.Customer;
@@ -69,7 +67,7 @@ public class ReserveTourHelperTest {
         reserveService = mock(ReserveService.class);
         priceCalculateSharedService = mock(PriceCalculateSharedService.class);
 
-        DozerBeanMapper dozerBeanMapper = new DozerBeanMapper();
+        Mapper dozerBeanMapper = DozerBeanMapperBuilder.buildDefault();
 
         reserveHelper.tourInfoSharedService = tourInfoSharedService;
         reserveHelper.reserveService = reserveService;
@@ -159,7 +157,7 @@ public class ReserveTourHelperTest {
 
         ReserveTourForm form = new ReserveTourForm();
         ReserveTourOutput output = new ReserveTourOutput();
-        when(reserveService.reserve((ReserveTourInput) anyObject())).thenReturn(
+        when(reserveService.reserve(any(ReserveTourInput.class))).thenReturn(
                 output);
 
         // run

--- a/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/searchtour/SearchTourControllerTest.java
+++ b/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/searchtour/SearchTourControllerTest.java
@@ -18,7 +18,7 @@ package org.terasoluna.tourreservation.app.searchtour;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -26,9 +26,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import java.util.ArrayList;
-import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.dozer.DozerBeanMapperBuilder;
+import org.dozer.Mapper;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +61,7 @@ public class SearchTourControllerTest {
 
     JodaTimeDateFactory dateFactory;
 
-    DozerBeanMapper beanMapper;
+    Mapper beanMapper;
 
     @Before
     public void setUp() {
@@ -74,7 +74,7 @@ public class SearchTourControllerTest {
         validator = new SearchTourFormDateValidator();
         dateFactory = new DefaultJodaTimeDateFactory();
 
-        beanMapper = new DozerBeanMapper();
+        beanMapper = DozerBeanMapperBuilder.buildDefault();
 
         searchTourController.tourInfoService = tourInfoService;
         searchTourController.validator = validator;
@@ -104,7 +104,7 @@ public class SearchTourControllerTest {
                                     NativeWebRequest webRequest,
                                     WebDataBinderFactory binderFactory) throws Exception {
 
-                                return new PageRequest(0, 50);
+                                return PageRequest.of(0, 50);
                             }
                         }).build();
     }
@@ -156,8 +156,8 @@ public class SearchTourControllerTest {
                 "/tours");
 
         // Set mock behavior for service method
-        when(tourInfoService.searchTour((TourInfoSearchCriteria) anyObject(),
-                (Pageable) anyObject())).thenReturn(
+        when(tourInfoService.searchTour(any(TourInfoSearchCriteria.class), any(
+                Pageable.class))).thenReturn(
                         new PageImpl<TourInfo>(new ArrayList<TourInfo>()));
 
         DateTime dateTime = dateFactory.newDateTime();
@@ -200,8 +200,8 @@ public class SearchTourControllerTest {
                 "/tours");
 
         // Set mock behavior for service method
-        when(tourInfoService.searchTour((TourInfoSearchCriteria) anyObject(),
-                (Pageable) anyObject())).thenReturn(
+        when(tourInfoService.searchTour(any(TourInfoSearchCriteria.class), any(
+                Pageable.class))).thenReturn(
                         new PageImpl<TourInfo>(new ArrayList<TourInfo>()));
 
         // Set invalid date such that custom date validator will fail


### PR DESCRIPTION
Please review #567 
------------------------------------------------------
1. Change version to 5.5.0.RC2
------------------------------------------------------

pom.xml 
terasoluna-tourreservation-domain/pom.xml 
terasoluna-tourreservation-env/pom.xml 
terasoluna-tourreservation-initdb/pom.xml 
terasoluna-tourreservation-selenium/pom.xml 
terasoluna-tourreservation-web/pom.xml 

------------------------------------------------------
2. Upgrade to dozer v6.2.0
------------------------------------------------------

https://github.com/DozerMapper/dozer/blob/master/docs/asciidoc/migration/v6-to-v61.adoc

・Mapping.xml XSD changed
terasoluna-tourreservation-domain/src/main/resources/META-INF/dozer/domain-mapping.xml 

・Updated dozer-spring package name
terasoluna-tourreservation-domain/src/test/resources/test-context.xml 
terasoluna-tourreservation-web/src/main/resources/META-INF/spring/applicationContext.xml 

・DozerBeanMapper usage is deprecated
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managecustomer/ManageCustomerControllerTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managereservation/ManageReservationControllerTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourHelperTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/searchtour/SearchTourControllerTest.java 

------------------------------------------------------
3. Fix build error of findOne and delete
------------------------------------------------------

・Error contents
The method findOne(Example) in the type QueryByExampleExecutor<Customer> is not applicable for the arguments (String)

・Error occurrence location

terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/customer/CustomerServiceImpl.java 
terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/reserve/AuthorizedReserveSharedServiceImpl.java 
terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/tourinfo/PriceCalculateSharedServiceImpl.java 
terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoSharedServiceImpl.java 
terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/userdetails/ReservationUserDetailsService.java 
terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImpl.java 
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/customer/CustomerServiceImplTest.java 
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplSecurityTest.java 
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplTest.java 
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoSharedServiceImplTest.java 

• Error cause
SpringBoot2.0 API changed.
https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html

· Correspondence to errors
https://stackoverflow.com/questions/49316751/spring-data-jpa-findone-change-to-optional-how-to-use-this
findOne(ID) -> findById(ID).orElse(null)
delete(ID) -> deleteById(ID)

------------------------------------------------------
4. Fix build error of setFirstResult
------------------------------------------------------

・Error contents
The method setFirstResult(int) in the type TypedQuery<TourInfo> is not applicable for the arguments (long)

・Error occurrence location
terasoluna-tourreservation-domain/src/main/java/org/terasoluna/tourreservation/domain/repository/tourinfo/TourInfoRepositoryImpl.java 

• Error cause
API changed.

· Correspondence to errors
setFirstResult(long) -> setFirstResult(int)
https://docs.oracle.com/javaee/6/api/javax/persistence/Query.html#setFirstResult(int)

------------------------------------------------------
5. Fix deprecated PageRequest(int, int)
------------------------------------------------------

・Error contents

The constructor PageRequest(int, int) is deprecated

・Error occurrence location
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/repository/tourinfo/TourInfoRepositoryImplTest.java 
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/tourinfo/TourInfoServiceImplTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/searchtour/SearchTourControllerTest.java 

• Error cause
API changed.

· Correspondence to errors
new PageRequest -> PageReques.of
https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/PageRequest.html

------------------------------------------------------
6. Fix deprecated anyObject()
------------------------------------------------------

・Error contents

The method anyObject() from the type ArgumentMatchers is deprecated

・Error occurrence location
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplSecurityTest.java 
terasoluna-tourreservation-domain/src/test/java/org/terasoluna/tourreservation/domain/service/reserve/ReserveServiceImplTest.java
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managecustomer/ManageCustomerControllerTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/managereservation/ManageReservationControllerTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourControllerTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourHelperTest.java 
terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/searchtour/SearchTourControllerTest.java 

• Error cause
API changed.

· Correspondence to errors

anyObject -> any
https://static.javadoc.io/org.mockito/mockito-core/2.2.7/org/mockito/ArgumentMatchers.html

------------------------------------------------------
7. Fix JasperReports  error
------------------------------------------------------
・Error contents
org.springframework.web.servlet.view.jasperreports.JasperReportsPdfView not found.

・Error occurrence location
spring-mvc.xml

• Error cause
Support for JasperReports for Spring 5 has been discontinued.

https://www.ibm.com/developerworks/jp/java/library/j-whats-new-in-spring-framework-5-theedom/index.html

· Correspondence to errors
TBD
