### PR TITLE
fix logback settings #657

### DIFF
--- a/terasoluna-tourreservation-env/configs/tomcat-postgresql/resources/logback.xml
+++ b/terasoluna-tourreservation-env/configs/tomcat-postgresql/resources/logback.xml
@@ -61,6 +61,20 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
+
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
     <level value="debug" />
   </logger>

--- a/terasoluna-tourreservation-env/configs/tomcat8-postgresql/resources/logback.xml
+++ b/terasoluna-tourreservation-env/configs/tomcat8-postgresql/resources/logback.xml
@@ -61,15 +61,21 @@
     <level value="info" />
   </logger>
 
-  <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-  <logger name="jdbc.sqltiming">
-    <level value="debug" />
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
   </logger>
 
-  <!-- only for development -->
-  <logger name="jdbc.resultsettable">
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
+  <logger name="org.hibernate.engine.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-tourreservation-env/configs/tomcat85-postgresql/resources/logback.xml
+++ b/terasoluna-tourreservation-env/configs/tomcat85-postgresql/resources/logback.xml
@@ -61,15 +61,21 @@
     <level value="info" />
   </logger>
 
-  <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-  <logger name="jdbc.sqltiming">
-    <level value="debug" />
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
   </logger>
 
-  <!-- only for development -->
-  <logger name="jdbc.resultsettable">
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
+  <logger name="org.hibernate.engine.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-tourreservation-env/configs/tomcat9-postgresql/resources/logback.xml
+++ b/terasoluna-tourreservation-env/configs/tomcat9-postgresql/resources/logback.xml
@@ -61,15 +61,21 @@
     <level value="info" />
   </logger>
 
-  <logger name="org.hibernate.engine.transaction">
-    <level value="debug" />
-  </logger>
-  <logger name="jdbc.sqltiming">
-    <level value="debug" />
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
   </logger>
 
-  <!-- only for development -->
-  <logger name="jdbc.resultsettable">
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
+  <logger name="org.hibernate.engine.transaction">
     <level value="debug" />
   </logger>
 

--- a/terasoluna-tourreservation-env/src/main/resources/logback.xml
+++ b/terasoluna-tourreservation-env/src/main/resources/logback.xml
@@ -61,6 +61,20 @@
     <level value="info" />
   </logger>
 
+  <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <level value="trace" />
+  </logger>
+
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
+  </logger>
+
+  <logger name="org.hibernate.SQL" additivity="true">
+    <level value="debug" />
+  </logger>
+  <logger name="org.hibernate.type">
+    <level value="trace" />
+  </logger>
   <logger name="org.hibernate.engine.transaction">
     <level value="debug" />
   </logger>

--- a/terasoluna-tourreservation-selenium/src/test/resources/logback.xml
+++ b/terasoluna-tourreservation-selenium/src/test/resources/logback.xml
@@ -30,13 +30,8 @@
     <level value="warn" />
   </logger>
 
-  <logger name="jdbc.sqltiming">
-    <level value="debug" />
-  </logger>
-
-  <!-- only for development -->
-  <logger name="jdbc.resultsettable">
-    <level value="debug" />
+  <logger name="org.springframework.jdbc.core.JdbcTemplate">
+    <level value="trace" />
   </logger>
 
   <root level="warn">


### PR DESCRIPTION
Please review #657.

It has been modified to match the following file.
https://github.com/terasolunaorg/terasoluna-gfw-web-multi-blank/blob/master/projectName-env/src/main/resources/logback.xml

`logback.xml` for `selenium` is exceptionally set to log output setting of `jdbc` only.