### PR TITLE
issue 555  reverse companyName and paymentCompanyname

### DIFF
--- a/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/views/managereservation/updateConfirm.jsp
+++ b/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/views/managereservation/updateConfirm.jsp
@@ -107,7 +107,7 @@
     </tr>
     <tr>
       <td><spring:message code="label.tr.common.paymentAccount" /></td>
-      <td colspan="3"><spring:message code="label.tr.common.companyName" /> <br /> <spring:message
+      <td colspan="3"><spring:message code="label.tr.common.paymentCompanyname" /> <br /> <spring:message
           code="label.tr.common.savingsAccount" /></td>
     </tr>
     <tr>
@@ -117,7 +117,7 @@
     </tr>
     <tr>
       <td><spring:message code="label.tr.common.paymentInquiry" /></td>
-      <td colspan="3"><spring:message code="label.tr.common.paymentCompanyname" /> <spring:message
+      <td colspan="3"><spring:message code="label.tr.common.companyName" /> <spring:message
           code="label.tr.common.companyTel" /> <spring:message code="label.tr.common.companyEmail" />
       </td>
     </tr>


### PR DESCRIPTION
Please review #555.



> Issue: The display positions of 'companyName' and 'paymentCompanyname' are opposite. #555
> 
> Test result:
>     before:

 ![modify_japanese](https://user-images.githubusercontent.com/51399043/170432316-827505f6-888c-4739-a1b6-5a622138919c.PNG)
![modify_english](https://user-images.githubusercontent.com/51399043/170432318-fbc88a5c-997b-46a6-848c-6cc3928b6db1.PNG)

>    after:

 ![modified_japanese](https://user-images.githubusercontent.com/51399043/170432421-660e4c5e-13fa-40a8-be39-f0780c80e961.PNG)
![modified_english](https://user-images.githubusercontent.com/51399043/170432425-731c14a2-d40d-48b0-b312-4ed2ae7bab45.PNG)


