### PR TITLE
fixed deprecated API #771

### DIFF
--- a/terasoluna-tourreservation-selenium/src/test/java/org/terasoluna/tourreservation/tourreserve/common/FunctionTestSupport.java
+++ b/terasoluna-tourreservation-selenium/src/test/java/org/terasoluna/tourreservation/tourreserve/common/FunctionTestSupport.java
@@ -18,9 +18,9 @@ package org.terasoluna.tourreservation.tourreserve.common;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -49,7 +49,7 @@ public abstract class FunctionTestSupport extends ApplicationObjectSupport {
 
     @Before
     public void setUp() {
-        driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
         driver.get(applicationContextUrl + "?locale=" + locale.getLanguage());
     }
 

--- a/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourControllerTest.java
+++ b/terasoluna-tourreservation-web/src/test/java/org/terasoluna/tourreservation/app/reservetour/ReserveTourControllerTest.java
@@ -29,7 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.security.web.context.SecurityContextPersistenceFilter;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -66,7 +67,9 @@ public class ReserveTourControllerTest {
         mockMvc = MockMvcBuilders.standaloneSetup(reserveTourController)
                 .setCustomArgumentResolvers(
                         new AuthenticationPrincipalArgumentResolver())
-                .addFilters(new SecurityContextPersistenceFilter()).build();
+                .addFilters(
+                        new SecurityContextHolderFilter(new HttpSessionSecurityContextRepository()))
+                .build();
     }
 
     @Test


### PR DESCRIPTION
Please review #771 

The [HttpSessionSecurityContextRepository](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/context/HttpSessionSecurityContextRepository.html), which was used by default in [SecurityContextPersistenceFilter](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/context/SecurityContextPersistenceFilter.html), is used for the constructor argument of [SecurityContextHolderFilter](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/context/SecurityContextHolderFilter.html).